### PR TITLE
Make Test::Spec import strict into test file

### DIFF
--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -54,6 +54,8 @@ sub import {
   my $class = shift;
   my $callpkg = caller;
 
+  strict->import;
+
   # specific imports requested
   if (@_) {
     $class->export_to_level(1, $callpkg, @_);
@@ -306,7 +308,7 @@ Test::Spec - Write tests in a declarative specification style
 
 =head1 SYNOPSIS
 
-  use Test::Spec;
+  use Test::Spec; # automatically turns on strict
 
   describe "A date" => sub {
 

--- a/t/auto_inherit.t
+++ b/t/auto_inherit.t
@@ -9,7 +9,6 @@ BEGIN { $^W = 0 }
 
 package Testcase::Spec::AutoInherit;
 use Test::Spec;
-use strict;
 use warnings;
 
 describe "Test::Spec" => sub {

--- a/t/import_strict.t
+++ b/t/import_strict.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+#
+# import_strict.t
+#
+########################################################################
+
+package Testcase::Spec::ImportStrict;
+use Test::Spec;
+use FindBin qw($Bin);
+use warnings;
+
+describe "Test::Spec" => sub {
+  describe "test file that violates strict" => sub {
+    my $tap = `$Bin/strict_violating_spec.pl 2>&1`;
+
+    it "does not compile" => sub {
+      like($tap, qr/aborted due to compilation errors/);
+    };
+
+    it "shows reason for failure" => sub {
+      like($tap,
+          qr/undefined_variable_violates_strict_mode_and_test_should_not_compile/);
+    }
+  }
+};
+
+runtests unless caller;

--- a/t/mocks.t
+++ b/t/mocks.t
@@ -10,7 +10,6 @@
 BEGIN { $^W = 0 }
 
 package Testcase::Spec::Mocks;
-use strict;
 use warnings;
 use Test::Spec;
 use base qw(Test::Spec);

--- a/t/mocks_imports.t
+++ b/t/mocks_imports.t
@@ -10,7 +10,6 @@
 BEGIN { $^W = 0 }
 
 package Testcase::Spec::Mocks::Imports;
-use strict;
 use warnings;
 use Test::Spec;
 use base qw(Test::Spec);

--- a/t/show_exeptions.t
+++ b/t/show_exeptions.t
@@ -10,7 +10,6 @@
 package Testcase::Spec::ShowExceptions;
 use Test::Spec;
 use FindBin qw($Bin);
-use strict;
 use warnings;
 
 describe "Test::Spec" => sub {

--- a/t/strict_violating_spec.pl
+++ b/t/strict_violating_spec.pl
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl
+#
+# strict_violating_spec.pl
+#
+# Expected to fail to compile because Test::Spec imports strict into test file.
+#
+########################################################################
+
+use Test::Spec;
+
+$undefined_variable_violates_strict_mode_and_test_should_not_compile;
+
+runtests unless caller;


### PR DESCRIPTION
so that one doesn't have to write too much of a boilerplate code in each test
file. Strict is good default and if needed, it could be turned off by "no
strict;".

For example Moose does same thing.

import of warnings will come in next commit
