### PR TITLE
Import warnings

### DIFF
--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -55,6 +55,7 @@ sub import {
   my $callpkg = caller;
 
   strict->import;
+  warnings->import;
 
   # specific imports requested
   if (@_) {
@@ -308,7 +309,7 @@ Test::Spec - Write tests in a declarative specification style
 
 =head1 SYNOPSIS
 
-  use Test::Spec; # automatically turns on strict
+  use Test::Spec; # automatically turns on strict and warnings
 
   describe "A date" => sub {
 

--- a/t/auto_inherit.t
+++ b/t/auto_inherit.t
@@ -9,7 +9,6 @@ BEGIN { $^W = 0 }
 
 package Testcase::Spec::AutoInherit;
 use Test::Spec;
-use warnings;
 
 describe "Test::Spec" => sub {
   it "should insert itself into the inheritance chain of any package that imports it" => sub {

--- a/t/import_warnings.t
+++ b/t/import_warnings.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+
+package Testcase::Spec::ImportWarnings;
+use Test::Spec;
+use FindBin qw($Bin);
+BEGIN { require "$Bin/test_helper.pl" };
+
+describe "Test::Spec" => sub {
+  describe "test file that contains code that triggers Perl warnings" => sub {
+    my $tap = capture_tap("perl_warning_spec.pl");
+
+    it "shows reason for the warning" => sub {
+      like($tap,
+          qr/Odd number of elements/);
+    }
+  }
+};
+
+runtests unless caller;

--- a/t/mocks.t
+++ b/t/mocks.t
@@ -10,7 +10,6 @@
 BEGIN { $^W = 0 }
 
 package Testcase::Spec::Mocks;
-use warnings;
 use Test::Spec;
 use base qw(Test::Spec);
 

--- a/t/mocks_imports.t
+++ b/t/mocks_imports.t
@@ -10,7 +10,6 @@
 BEGIN { $^W = 0 }
 
 package Testcase::Spec::Mocks::Imports;
-use warnings;
 use Test::Spec;
 use base qw(Test::Spec);
 use Package::Stash;

--- a/t/perl_warning_spec.pl
+++ b/t/perl_warning_spec.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+#
+# perl_warning_spec.pl
+#
+# Expected to show "Odd number of elements" warning because Test::Spec
+# imports warnings into test file.
+#
+########################################################################
+
+use Test::Spec;
+
+describe "Test::Spec" => sub {
+  it "turns on perl warnings in test file" => sub {
+    my %hash = ( "with" => "odd", "number" => "of", "elements" );
+    pass;
+  };
+};
+
+runtests unless caller;

--- a/t/show_exeptions.t
+++ b/t/show_exeptions.t
@@ -10,7 +10,6 @@
 package Testcase::Spec::ShowExceptions;
 use Test::Spec;
 use FindBin qw($Bin);
-use warnings;
 BEGIN { require "$Bin/test_helper.pl" };
 
 describe "Test::Spec" => sub {


### PR DESCRIPTION
so that one doesn't have to write too much of a boilerplate code in each
test file.
