### PR TITLE
Make it possible to easily disable specs

### DIFF
--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -17,8 +17,8 @@ use constant { DEFINITION_PHASE => 0, EXECUTION_PHASE => 1 };
 our $TODO;
 our $Debug = $ENV{TEST_SPEC_DEBUG} || 0;
 
-our @EXPORT      = qw(runtests describe before after it they *TODO
-                      share shared_examples_for it_should_behave_like
+our @EXPORT      = qw(runtests describe xdescribe before after it xit they
+                      xthey *TODO share shared_examples_for it_should_behave_like
                       spec_helper);
 our @EXPORT_OK   = ( @EXPORT, qw(DEFINITION_PHASE EXECUTION_PHASE $Debug) );
 our %EXPORT_TAGS = ( all => \@EXPORT_OK,
@@ -151,6 +151,11 @@ sub _execute_tests {
   }
   $class->builder->done_testing;
 }
+
+# used to easily disable suites/specs during development
+sub xdescribe {}
+sub xit {}
+sub xthey {}
 
 # it DESC => CODE
 # it CODE
@@ -599,6 +604,10 @@ C<describe> blocks with the same name are allowed. They do not replace each
 other, rather subsequent C<describe>s extend the existing one of the same
 name.
 
+=item xdescribe
+
+Specification contexts may be disabled by calling xdescribe() instead of
+describe().
 
 =item it SPECIFICATION => CODE
 
@@ -636,6 +645,10 @@ items, so the verb agrees with the noun:
     };
     they "put the lotion in the basket"; # TODO
   };
+
+=item xit/xthey
+
+Examples may be disabled by calling xit()/xthey() instead of it()/they().
 
 =item before each => CODE
 

--- a/t/disabled.t
+++ b/t/disabled.t
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+#
+# disabled.t
+#
+# Disabled specs.
+#
+########################################################################
+#
+
+package Testcase::Spec::Disabled;
+use Test::Spec;
+
+describe 'Test::Spec' => sub {
+    xdescribe 'disabled spec' => sub {
+        it 'should not execute any examples' => sub {
+            fail;
+        };
+    };
+
+    xit 'should not execute disabled example' => sub {
+        fail;
+    };
+
+    it 'should execute enabled example' => sub {
+        pass;
+    };
+};
+
+runtests unless caller;


### PR DESCRIPTION
during development by prefixing describe/it/they with letter x.

Idea taken from JavaSript Jasmine BDD framework:
  https://github.com/pivotal/jasmine/wiki/Suites-and-specs

Rationale:

While doing TDD - sometimes one has to write other code/tests before he makes
current test pass so it would be nice to have some quick way to temporarily
disable it.
