### PR TITLE
Fix the tests for Test::Builder1.5 / TAP version 13

### DIFF
--- a/t/runtests_subset.t
+++ b/t/runtests_subset.t
@@ -29,7 +29,7 @@ describe "Test::Spec" => sub {
       $tap = capture_tap("subset_spec.pl", "oNe");
     };
     it "should run the requested examples" => sub {
-      like $tap, qr/^ok \d+ - Test One/;
+      like $tap, qr/^ok \d+ - Test One/m;
     };
     it "should run ONLY the requested examples" => sub {
       unlike $tap, qr/^ok \d+ - Test Two/;
@@ -44,7 +44,7 @@ describe "Test::Spec" => sub {
       $tap = capture_tap("subset_spec.pl");
     };
     it "should run the requested examples" => sub {
-      like $tap, qr/^ok \d+ - Test One/;
+      like $tap, qr/^ok \d+ - Test One/m;
     };
     it "should run ONLY the requested examples" => sub {
       unlike $tap, qr/^ok \d+ - Test Two/;
@@ -59,7 +59,7 @@ describe "Test::Spec" => sub {
       $tap = capture_tap("subset_spec.pl","tWo");
     };
     it "should run the explicit example" => sub {
-      like $tap, qr/^ok \d+ - Test Two/;
+      like $tap, qr/^ok \d+ - Test Two/m;
     };
     it "should *not* run the SPEC example" => sub {
       unlike $tap, qr/^ok \d+ - Test One/;


### PR DESCRIPTION
In Test::Builder 1.5, TAP starts with a version header like...

```
TAP version 13
ok 1 - foo
ok 2 - bar
1..2
```

This patch just checks to see if the requisite test is output, not that
it's the first line (or the first test).

You can find the latest Test::Builder 1.5 alpha here.
https://metacpan.org/release/MSCHWERN/Test-Simple-1.005000_005/
