### PR TITLE
Compare plain perl data structures with Test::Deep

### DIFF
--- a/lib/Test/Spec/Mocks.pm
+++ b/lib/Test/Spec/Mocks.pm
@@ -286,35 +286,14 @@ sub _make_mock {
     my $self = shift;
     return unless defined $self->_args;
 
-    if (!defined $self->_given_args || scalar(@{$self->_args}) != scalar(@{$self->_given_args})) {
-        return "Number of arguments don't match expectation";
+    my @got = $self->_given_args;
+    my @expected = $self->_args;
+    my ($same, $stack) = Test::Deep::cmp_details(\@got, \@expected);
+    if ( !$same ) {
+      return Test::Deep::deep_diag($stack);
     }
-    my @problems = ();
-    for my $i (0..$#{$self->_args}) {
-      my $a = $self->_args->[$i];
-      my $b = $self->_given_args->[$i];
-      unless ($self->_match_arguments($a, $b)) {
-        $a = 'undef' unless defined $a;
-        $b = 'undef' unless defined $b;
-        push @problems, sprintf("Expected argument in position %d to be '%s', but it was '%s'", $i, $a, $b);
-      }
-    }
-    return @problems;
-  }
 
-  sub _match_arguments {
-    my $self = shift;
-    my ($a, $b) = @_;
-
-    return 1 if !defined $a && !defined $b;
-    return unless defined $a && defined $b;
-
-    # compare objects using operator overloading
-    return $a eq $b if Scalar::Util::blessed($a) || Scalar::Util::blessed($b);
-
-    # compare vanilla structures
-    my ($same, $stack_diff) = Test::Deep::cmp_details($a, $b);
-    return $same;
+    return; # args are the same
   }
 
   #
@@ -979,10 +958,11 @@ I<This method is alpha and will probably change in a future release.>
 =item with(@arguments)
 
 Configures the mocked method so that it must be called with arguments as
-specified. The arguments will be compared using the "eq" operator, so it works
-for most scalar values with no problem. If you want to check objects here,
-they must be the exact same instance or you must overload the "eq" operator to
-provide the behavior you desire.
+specified. The arguments are compared deeply: scalars are compared by value,
+arrays and hashes must have the same elements and references must be blessed
+into the same class:
+
+  $lwp->expects('request')->with('GET', '/url');
 
 =item raises($exception)
 

--- a/lib/Test/Spec/Mocks.pm
+++ b/lib/Test/Spec/Mocks.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Carp ();
 use Scalar::Util ();
+use Test::Deep::NoTest ();
 
 require Test::Spec;
 
@@ -304,9 +305,16 @@ sub _make_mock {
   sub _match_arguments {
     my $self = shift;
     my ($a, $b) = @_;
+
     return 1 if !defined $a && !defined $b;
     return unless defined $a && defined $b;
-    return $a eq $b;
+
+    # compare objects using operator overloading
+    return $a eq $b if Scalar::Util::blessed($a) || Scalar::Util::blessed($b);
+
+    # compare vanilla structures
+    my ($same, $stack_diff) = Test::Deep::cmp_details($a, $b);
+    return $same;
   }
 
   #

--- a/lib/Test/Spec/Mocks.pm
+++ b/lib/Test/Spec/Mocks.pm
@@ -725,7 +725,9 @@ In this example, we are testing that C<read_line> is called once and only
 once (the default for mocks).
 
   it "returns true when a yes_or_no question is answered 'yes'" => sub {
-    my $console_mock = mock()->expects('read_line')->returns("yes");
+    my $console_mock = mock();
+    $console_mock->expects('read_line')
+                 ->returns("yes");
     # $console_mock->read_line returns "yes"
     ok( $asker->yes_or_no($console_mock, "Am I awesome?") );
   };

--- a/t/mocks.t
+++ b/t/mocks.t
@@ -252,7 +252,6 @@ describe 'Test::Mocks' => sub {
       ok($verified);
     };
 
-
     describe "raising exceptions" => sub {
       it "raises the exception" => sub {
         my $stub = stub();
@@ -342,6 +341,17 @@ describe 'Test::Mocks' => sub {
         is(scalar($expectation->problems), 0);
       };
 
+      it "passes when expecting an empty hash and given a different one" => sub {
+        $expectation->with({});
+        $stub->run({});
+        is(scalar($expectation->problems), 0);
+      };
+
+      it "passes when given a copy of the data structure it is expecting" => sub {
+        $expectation->with({ key => 'value' });
+        $stub->run({ key => 'value' });
+        is(scalar($expectation->problems), 0);
+      };
     };
 
     describe "call count expectation" => sub {

--- a/t/mocks.t
+++ b/t/mocks.t
@@ -36,7 +36,6 @@ use List::Util ();
 {
   package TestProduct;
   our @ISA = qw(TestORM);
-  use overload eq => sub { 1 }; # stub for with() test
   sub prices { 'ORIGINAL' }
   sub desc {
     # normally "bottom middle top"
@@ -279,6 +278,9 @@ describe 'Test::Mocks' => sub {
         $expectation->cancel; # don't verify
       };
 
+      my $num_args_mismatch_err = qr/^Compared array length/;
+      my $args_mismatch_err = qr/^Compared .*(?!length)/;
+
       it "passes when expecting no arguments" => sub {
         $expectation->with();
         $stub->run();
@@ -288,7 +290,7 @@ describe 'Test::Mocks' => sub {
       it "fails when expecting no arguments and one argument given" => sub {
         $expectation->with();
         $stub->run(1);
-        contains_ok([$expectation->problems], qr/^Number of arguments don't match expectation$/);
+        contains_ok([$expectation->problems], $num_args_mismatch_err);
       };
 
       it "passes when expecting one String('Foo') argument" => sub {
@@ -300,19 +302,25 @@ describe 'Test::Mocks' => sub {
       it "fails when expecting one String('Foo') argument but given none" => sub {
         $expectation->with("Foo");
         $stub->run();
-        contains_ok([$expectation->problems], qr/^Number of arguments don't match expectation$/);
+        contains_ok([$expectation->problems], $num_args_mismatch_err);
       };
 
       it "fails when expecting one String('Foo') argument but given two" => sub {
         $expectation->with("Foo");
         $stub->run("Foo", "Bar");
-        contains_ok([$expectation->problems], qr/^Number of arguments don't match expectation$/);
+        contains_ok([$expectation->problems], $num_args_mismatch_err);
+      };
+
+      it "fails when expecting many string arguments but given different arguments" => sub {
+        $expectation->with("Foo", "Bar", "Baz");
+        $stub->run("Foo", "Bar", "Bat");
+        contains_ok([$expectation->problems], $args_mismatch_err);
       };
 
       it "fails when expecting one String('Foo') argument but given a different String" => sub {
         $expectation->with("Foo");
         $stub->run("Bar");
-        contains_ok([$expectation->problems], qr/^Expected argument in position 0 to be 'Foo', but it was 'Bar'$/);
+        contains_ok([$expectation->problems], $args_mismatch_err);
       };
 
       it "passes when expecting an object argument that was given" => sub {
@@ -326,30 +334,24 @@ describe 'Test::Mocks' => sub {
         my $obj = TestOO->new;
         $expectation->with($obj);
         $stub->run();
-        contains_ok([$expectation->problems], qr/^Number of arguments don't match expectation$/);
+        contains_ok([$expectation->problems], $num_args_mismatch_err);
       };
 
-      it "fails when expecting an object argument but given a different one" => sub {
-        $expectation->with(TestOO->new);
-        $stub->run(TestOO->new);
-        contains_ok([$expectation->problems], qr/^Expected argument in position 0 to be 'TestOO=HASH.+ but it was 'TestOO=HASH/);
-      };
-
-      it "passes when expecting an object argument and given a different one that compares with eq operator" => sub {
+      it "passes when expecting an object argument and given a different one in the same class" => sub {
         $expectation->with(TestProduct->new);
         $stub->run(TestProduct->new);
-        is(scalar($expectation->problems), 0);
-      };
-
-      it "passes when expecting an empty hash and given a different one" => sub {
-        $expectation->with({});
-        $stub->run({});
         is(scalar($expectation->problems), 0);
       };
 
       it "passes when given a copy of the data structure it is expecting" => sub {
         $expectation->with({ key => 'value' });
         $stub->run({ key => 'value' });
+        is(scalar($expectation->problems), 0);
+      };
+
+      it "does a deep comparison" => sub {
+        $expectation->with({ product => TestProduct->new });
+        $stub->run({ product => TestProduct->new });
         is(scalar($expectation->problems), 0);
       };
     };


### PR DESCRIPTION
Hi Philip,

I'm trying to verify perl datastructures ala:

```
$s3->expects('put')
   ->with('test-bucket', 'test-id', 'my data', {})                              
   ->returns(1);
```

but it would always fail because it uses `eq` to compare everything. What do you think about doing a deep comparison instead? Can Test::Spec already do this?

I'm happy to update the docs etc but wanted to get your thoughts before jumping in

It is a nice little module, thanks for it.

Andy