### PR TITLE
Fix failure when using Alpha branch of Test::More

### DIFF
--- a/t/define.t
+++ b/t/define.t
@@ -114,11 +114,16 @@ is( $on_enter, $on_leave, "entered and left symmetrically" );
 is( A->phase, Test::Spec::DEFINITION_PHASE, "definition phase" );
 
 {
-  no warnings 'once';
-  my $stub = Stub->new;
-  local *A::builder          = sub { $stub };
-  local *Test::More::builder = sub { $stub };
-  A->runtests;
+  if ($INC{'Test/Stream.pm'}) {
+    Test::Stream->intercept(sub { A->runtests });
+  }
+  else {
+    no warnings 'once';
+    my $stub = Stub->new;
+    local *A::builder          = sub { $stub };
+    local *Test::More::builder = sub { $stub };
+    A->runtests;
+  }
 }
 
 is( A->phase, Test::Spec::EXECUTION_PHASE, "execution phase" );


### PR DESCRIPTION
The Alpha branch of Test-Simple and friends is quickly approaching
stable status. It is already merged into blead perl to find issues like
this.

This patch makes your test suite pass with both old and new versions of
Test::Builder.

Please see https://github.com/Test-More/test-more/issues/474  for the
discussion of this issue.