### PR TITLE
don't fail with argument expectation when method never called

### DIFF
--- a/lib/Test/Spec/Mocks.pm
+++ b/lib/Test/Spec/Mocks.pm
@@ -302,6 +302,7 @@ sub _make_mock {
  sub _check_eq_args {
     my $self = shift;
     return unless defined $self->_eq_args;
+    return unless $self->_call_count;
 
     if (!defined $self->_given_args || scalar(@{$self->_eq_args}) != scalar(@{$self->_given_args})) {
         return "Number of arguments don't match expectation";
@@ -330,6 +331,7 @@ sub _make_mock {
   sub _check_deep_args {
     my $self = shift;
     return unless defined $self->_deep_args;
+    return unless $self->_call_count;
 
     my @got = $self->_given_args;
     my @expected = $self->_deep_args;

--- a/t/mocks.t
+++ b/t/mocks.t
@@ -288,6 +288,18 @@ describe 'Test::Mocks' => sub {
           is(scalar($expectation->problems), 0);
         };
 
+        it "passes when expecting no arguments and never called" => sub {
+          $expectation->any_number->$with_method();
+          # $stub->run();  # nope!
+          is(scalar($expectation->problems), 0);
+        };
+
+        it "passes when expecting one argument and never called" => sub {
+          $expectation->any_number->$with_method("Foo");
+          # $stub->run();  # nope!
+          is(scalar($expectation->problems), 0);
+        };
+
         it "fails when expecting no arguments and one argument given" => sub {
           $expectation->$with_method();
           $stub->run(1);


### PR DESCRIPTION
Currently, if you create an expectation that a method will be called `any_number()` of times, and that when it's called, it should be called `with()` some particular args, it fails if the method is never called. For example, this code:

```
Foo::Bar->expects('baz')->any_number->with(arg => $val)->returns($stuff);
```

If `Foo::Bar->baz()` never gets called, we see this test failure:

```
#    Number of arguments don't match expectation.
```

(I am indebted to @cavemanpi, my pair-programmer, who helped me find and fix this bug.)
