### PR TITLE
Fix #24 Avoid circular references so objects go out of scope in a predictable order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 Makefile
 blib
 pm_to_blib

--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -130,7 +130,8 @@ sub runtests {
   my @which = @_         ? @_           :
               $ENV{SPEC} ? ($ENV{SPEC}) : ();
 
-  return $class->_execute_tests( $class->_pick_tests(@which) );
+  my @tests = $class->_pick_tests(@which);
+  return $class->_execute_tests( @tests );
 }
 
 sub builder {
@@ -153,13 +154,12 @@ sub _execute_tests {
     $test->run();
   }
 
-  $class->builder->done_testing;
-
-  # given we just called done_testing above, we can't call runtests
-  # again so we can clean up any references here.
-  # We have quite a few circular deps to clean up!
-  # Ensure we don't keep any references to user variables so they go out of scope as expected
+  # Ensure we don't keep any references to user variables so they go out
+  # of scope in a predictable fashion.
   %_Package_Tests = %_Package_Contexts = ();
+
+  # XXX: this doesn't play nicely with Test::NoWarnings and friends
+  $class->builder->done_testing;
 }
 
 # it DESC => CODE

--- a/lib/Test/Spec/Context.pm
+++ b/lib/Test/Spec/Context.pm
@@ -304,7 +304,6 @@ sub _materialize_tests {
         name        => $sub_name,
         description => $description,
         code        => $t->{code},
-#        stack       => \@context_stack,
         context     => $self,
         builder     => $self->_builder,
       });

--- a/lib/Test/Spec/Example.pm
+++ b/lib/Test/Spec/Example.pm
@@ -1,0 +1,144 @@
+package Test::Spec::Example;
+
+# Purpose: represents an `it` block
+
+use strict;
+use warnings;
+
+########################################################################
+# NO USER-SERVICEABLE PARTS INSIDE.
+########################################################################
+
+use Carp ();
+use Scalar::Util ();
+
+sub new {
+  my ($class, $args) = @_;
+
+  if (!$args || ref($args) ne 'HASH') {
+    Carp::croak "usage: $class->new(\\%args)";
+  }
+
+  my $self = bless {}, $class;
+  foreach my $attr ( qw/name description code builder context/ ) {
+    $self->{$attr} = $args->{$attr} || Carp::croak "$attr missing";
+  }
+
+  Scalar::Util::weaken($self->{context});
+
+  return $self;
+}
+
+sub name        { shift->{name} }
+sub description { shift->{description} }
+sub builder     { shift->{builder} }
+sub context     { shift->{context} }
+
+# Build a stack from the starting context
+# down to the current context
+sub stack {
+  my ($self) = @_;
+
+  my $ctx = $self->context;
+
+  my @ancestors = $ctx;
+  while ( $ctx = $ctx->parent ) {
+      push @ancestors, $ctx;
+  }
+
+  return reverse(@ancestors);
+}
+
+sub run  {
+  my ($self) = @_;
+
+  # clobber Test::Builder's ok() method just like Test::Class does,
+  # but without screwing up underscores.
+  no warnings 'redefine';
+  my $orig_builder_ok = \&Test::Builder::ok;
+  local *Test::Builder::ok = sub {
+    my ($builder,$test,$desc) = splice(@_,0,3);
+    $desc ||= $self->description;
+    local $Test::Builder::Level = $Test::Builder::Level+1;
+    $orig_builder_ok->($builder, $test, $desc, @_);
+  };
+
+  # This recursive closure essentially does this
+  # $outer->contextualize {
+  #   $outer->before_each
+  #   $inner->contextualize {
+  #     $inner->before_each
+  #     $anon->contextualize {
+  #       $anon->before_each (no-op)
+  #         execute test
+  #       $anon->after_each (no-op)
+  #     }
+  #     $inner->after_each
+  #   }
+  #   $outer->after_each
+  # }
+  #
+  my $runner;
+  $runner = sub {
+    my ($ctx, @remainder) = @_;
+    $ctx->contextualize(sub {
+      $ctx->_run_before_all_once;
+      $ctx->_run_before('each');
+      if ( @remainder ) {
+        $runner->(@remainder);
+      }
+      else {
+        $ctx->_in_anonymous_context(sub { $self->{code}->() });
+      }
+      $ctx->_run_after('each');
+      # "after 'all'" only happens during context destruction (DEMOLISH).
+      # This is the only way I can think to make this work right
+      # in the case that only specific test methods are run.
+      # Otherwise, the global teardown would only happen when you
+      # happen to run the last test of the context.
+    });
+  };
+
+  # Run the test
+  eval { $runner->($self->stack) };
+
+  # And trap any errors
+  if (my $err = $@) {
+    my $builder = $self->builder;
+    my $description = $self->description;
+
+    # eval in case stringification overload croaks
+    chomp($err = eval { $err . '' } || 'unknown error');
+    my ($file,$line);
+    ($file,$line) = ($1,$2) if ($err =~ s/ at (.+?) line (\d+)\.\Z//);
+
+    # disable ok()'s diagnostics so we can generate a custom TAP message
+    my $old_diag = $builder->no_diag;
+    $builder->no_diag(1);
+    # make sure we can restore no_diag
+    eval { $builder->ok(0, $description) };
+    my $secondary_err = $@;
+    # no_diag needs a defined value, so double-negate it to get either '' or 1
+    $builder->no_diag(!!$old_diag);
+
+    unless ($builder->no_diag) {
+      # emulate Test::Builder::ok's diagnostics, but with more details
+      my ($msg,$diag_fh);
+      if ($builder->in_todo) {
+        $msg = "Failed (TODO)";
+        $diag_fh = $builder->todo_output;
+      }
+      else {
+        $msg = "Failed";
+        $diag_fh = $builder->failure_output;
+      }
+      print {$diag_fh} "\n" if $ENV{HARNESS_ACTIVE};
+      print {$builder->failure_output} qq[#   $msg test '$description' by dying:\n];
+      print {$builder->failure_output} qq[#     $err\n];
+      print {$builder->failure_output} qq[#     at $file line $line.\n] if defined($file);
+    }
+    die $secondary_err if $secondary_err;
+  }
+}
+
+1;

--- a/lib/Test/Spec/TodoExample.pm
+++ b/lib/Test/Spec/TodoExample.pm
@@ -1,0 +1,40 @@
+package Test::Spec::TodoExample;
+
+# Purpose: represents a `xit` block (ie. a pending/todo test)
+
+use strict;
+use warnings;
+
+use Test::Spec qw(*TODO);
+
+sub new {
+    my ($class, $args) = @_;
+
+    my $self = bless {}, $class;
+    $self->{name}        = $args->{name};
+    $self->{description} = $args->{description};
+    $self->{reason}      = $args->{reason} || '(unimplemented)';
+    $self->{builder}     = $args->{builder};
+
+    return $self;
+}
+
+# Attributes
+sub name        { shift->{name} }
+sub description { shift->{description} }
+sub reason      { shift->{reason} }
+sub builder     { shift->{builder} }
+
+# Methods
+sub run {
+    my ($self) = @_;
+
+    local $TODO = $self->reason;
+    my $builder = $self->builder;
+
+    $builder->todo_start($TODO);
+    $builder->ok(1, $self->description); # XXX: could fail the TOOD (or even run it?)
+    $builder->todo_end();
+}
+
+1;

--- a/t/predictable_destroy.pl
+++ b/t/predictable_destroy.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+#
+# predictable_destroy.pl
+#
+# Objects should be destroyed in a predictable order during the RUN phase
+# Expected to print out "DESTROYED IN RUN PHASE"
+#
+########################################################################
+#
+
+package Testcase::Spec::PredictableDestroy;
+use Test::Spec;
+
+{
+    package Foo;
+    sub new { bless {}, $_[0] }
+    sub DESTROY { warn("DESTROYED IN ${^GLOBAL_PHASE}") }
+};
+
+describe "Test::Spec::Mocks" => sub {
+  my $x = Foo->new;
+  it "destroys objects in the run phase" => sub {
+      ok $x;
+  };
+};
+
+runtests unless caller;

--- a/t/predictable_destroy.pl
+++ b/t/predictable_destroy.pl
@@ -14,7 +14,7 @@ use Test::Spec;
 {
     package Foo;
     sub new { bless {}, $_[0] }
-    sub DESTROY { warn("DESTROYED IN ${^GLOBAL_PHASE}") }
+    sub DESTROY { warn("$_[0] DESTROYED IN ${^GLOBAL_PHASE}") }
 };
 
 describe "Test::Spec::Mocks" => sub {
@@ -24,4 +24,4 @@ describe "Test::Spec::Mocks" => sub {
   };
 };
 
-runtests unless caller;
+runtests() unless caller;

--- a/t/predictable_destroy_spec.t
+++ b/t/predictable_destroy_spec.t
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+#
+# predictable_destroy_spec.t
+#
+# Ensure we don't keep references around to objects so they
+# are destroyed in a predictable order
+#
+########################################################################
+#
+
+package Testcase::Spec::PredictableDestroy;
+use Test::Spec;
+
+use FindBin qw($Bin);
+BEGIN { require "$Bin/test_helper.pl" };
+
+describe "Test::Spec" => sub {
+  my $tap = capture_tap("predictable_destroy.pl");
+
+  it "destroys objects in the run phase" => sub {
+      unlike $tap => qr/DESTROYED IN DESTRUCT/;
+  };
+
+  it "avoids global destruction" => sub {
+      unlike $tap => qr/during global destruction/;
+  };
+};
+
+runtests unless caller;


### PR DESCRIPTION
 * _ixhash() has a habit of not going out of scope cleanly so replacing with a standard hash where order doesn't matter
 * $runner recursive closure leaked a lot of references