### PR TITLE
Improve RELEASE_CHECKLIST

### DIFF
--- a/RELEASE_CHECKLIST
+++ b/RELEASE_CHECKLIST
@@ -3,3 +3,6 @@
 * Update Changes
 * make manifest
 * make test
+* make disttest
+* make dist
+* send on PAUSE the .tar.gz produced here, not a Github URL


### PR DESCRIPTION
The v0.50 release has not been properly sent to PAUSE. We (the Perl toolchain gang) suspect ANDYJONES posted a Github URL. You're welcome on #toolchain on irc.perl.org to tell us what happened.

To reduce the chance of this happenning again, this patch improves RELEASE_CHECKLIST to avoid the v0.50 failure.

Cc: @haarg, @kentfredric
