### PR TITLE
describe blocks not executing in order

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,7 @@ t/import_strict.t
 t/import_warnings.t
 t/mocks.t
 t/mocks_imports.t
+t/ordering.t
 t/perl_warning_spec.pl
 t/predictable_destroy.pl
 t/predictable_destroy_spec.t

--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -203,7 +203,7 @@ sub describe(@) {
     $container = $_Current_Context->context_lookup;
   }
   else {
-    $container = $_Package_Contexts{$package} ||= {};
+    $container = $_Package_Contexts{$package} ||= Test::Spec::_ixhash();
   }
 
   __PACKAGE__->_accumulate_examples({

--- a/t/ordering.t
+++ b/t/ordering.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+#
+# ordering.pl
+#
+# Verify that describe blocks are executed in order of definition.
+#
+########################################################################
+#
+
+use Test::Spec;
+use FindBin qw($Bin);
+BEGIN { require "$Bin/test_helper.pl" };
+
+my $num_contexts = 10;
+
+my $next_expected = 1;
+for my $num (1..$num_contexts) {
+  describe "Context $num" => sub {
+    it "should run in position $num" => sub {
+      is $next_expected++, $num;
+    };
+  }
+};
+
+runtests(@ARGV) unless caller;


### PR DESCRIPTION
Hi. Thanks for Test::Spec. It's really helping to make my tests more readable.

I think I found a problem in the order that blocks are executed, unless I'm missing something.
Looks like the top-level containers in the %_Package_Contexts do not have have their order maintained.

I added a test, t/ordering.t, that demonstrates the problem.

All I did was change it to use the _ixhash() function to create those containers rather than a naked hash.
