### PR TITLE
CODE: split runtests and done_testing

### DIFF
--- a/lib/Test/Spec/Context.pm
+++ b/lib/Test/Spec/Context.pm
@@ -375,18 +375,18 @@ sub _run_on_leave {
 # for giving individual tests mortal, anonymous contexts that are used for
 # mocking/stubbing hooks.
 sub _in_anonymous_context {
-  my ($self,$code) = @_;
+  my ($self,$code,$example) = @_;
   my $context = Test::Spec::Context->new;
   $context->name('');
   $context->parent($self);
   $context->class($self->class);
-  $context->contextualize($code);
+  $context->contextualize($code, $example);
 }
 
 # Runs $code within a context (specifically, having been wrapped with
 # on_enter/on_leave setup and teardown).
 sub contextualize {
-  my ($self,$code) = @_;
+  my ($self,$code,$example) = @_;
   local $Test::Spec::_Current_Context = $self;
   local $self->{_has_run_on_enter} = {};
   local $self->{_has_run_on_leave} = {};
@@ -397,7 +397,7 @@ sub contextualize {
   push @errs, $@ if $@;
 
   if (not @errs) {
-    eval { $code->() };
+    eval { $code->($example) };
     push @errs, $@ if $@;
   }
 

--- a/lib/Test/Spec/Example.pm
+++ b/lib/Test/Spec/Example.pm
@@ -131,7 +131,7 @@ sub _runner {
       $self->_runner(@remainder);
     }
     else {
-      $ctx->_in_anonymous_context($self->code);
+      $ctx->_in_anonymous_context($self->code, $self);
     }
     $ctx->_run_after('each');
     # "after 'all'" only happens during context destruction (DEMOLISH).
@@ -139,7 +139,7 @@ sub _runner {
     # in the case that only specific test methods are run.
     # Otherwise, the global teardown would only happen when you
     # happen to run the last test of the context.
-  });
+  }, $self);
 }
 
 1;

--- a/t/example_in_handler.t
+++ b/t/example_in_handler.t
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl
+package Testcase::Spec::ExampleInHandler;
+use Test::Spec;
+
+describe "Test::Spec" => sub {
+  it "should pass an example instance" => sub {
+    my ($example) = @_;
+    ok($example);
+    isa_ok($example, 'Test::Spec::Example');
+  };
+};
+
+runtests unless caller;


### PR DESCRIPTION
New words: runtests_no_plan, done_testing.
