### PR TITLE
Rework running of 'after all' to not rely on global destruction

### DIFF
--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -178,7 +178,7 @@ sub _cleanup_complete_contexts {
   if($next_test){
     my(@next_stack) = $next_test->stack;
     my $n=0;
-    while($n <= $#next_stack && $#stack > 0 && $next_stack[$n] == $stack[0]){
+    while($n <= $#next_stack && scalar(@stack) > 0 && $next_stack[$n] == $stack[0]){
         shift @stack;
         $n++;
     }

--- a/lib/Test/Spec/Context.pm
+++ b/lib/Test/Spec/Context.pm
@@ -66,18 +66,6 @@ sub clone {
   return $clone;
 }
 
-# The reference we keep to our parent causes the garbage collector to
-# destroy the innermost context first, which is what we want. If that
-# becomes untrue at some point, it will be easy enough to descend the
-# hierarchy and run the after("all") tests that way.
-sub DESTROY {
-  my $self = shift;
-  # no need to tear down what was never set up
-  if ($self->_has_run_before_all) {
-    $self->_run_after_all_once;
-  }
-}
-
 sub name {
   my $self = shift;
   $self->{_name} = shift if @_;
@@ -424,7 +412,7 @@ sub contextualize {
 
 #
 # Copyright (c) 2010-2011 by Informatics Corporation of America.
-# 
+#
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl itself.
 #

--- a/lib/Test/Spec/Example.pm
+++ b/lib/Test/Spec/Example.pm
@@ -134,11 +134,8 @@ sub _runner {
       $ctx->_in_anonymous_context($self->code, $self);
     }
     $ctx->_run_after('each');
-    # "after 'all'" only happens during context destruction (DEMOLISH).
-    # This is the only way I can think to make this work right
-    # in the case that only specific test methods are run.
-    # Otherwise, the global teardown would only happen when you
-    # happen to run the last test of the context.
+    # After all is handled by Spec.pm itself as it requires
+    # knowledge that crosses contexts.
   }, $self);
 }
 

--- a/t/disabled.t
+++ b/t/disabled.t
@@ -37,4 +37,3 @@ test_passed('Test::Spec should execute enabled "it" example');
 test_passed('Test::Spec should execute enabled "they" example');
 
 done_testing();
-

--- a/t/run_after_spec.t
+++ b/t/run_after_spec.t
@@ -1,0 +1,57 @@
+use Test::Spec;
+my($first_nested_after, $second_nested_after, $inner_after, $second_inner_after, $todo_after);
+
+describe "outer describe block" => sub {
+    describe "inner block" => sub {
+        describe "first nested block" => sub {
+            it "runs first" => sub {
+                ok(! $first_nested_after ,"first nested block");
+            };
+            after all => sub {
+                $first_nested_after = 1;
+                ok(1, "after all - first nested block");
+            };
+        };
+        describe "second nested block" => sub {
+            it "first nested after has run by now" => sub {
+                ok($first_nested_after, "first nested after has run");
+            };
+            it "doesn't run second nest after until all it's have run" => sub {
+                ok($second_nested_after, "second nested after hasn't run yet")
+            };
+            after all => sub {
+                $second_nested_after = 1;
+                ok(1, "after all - second nested block");
+            };
+        };
+
+        after all => sub {
+            $inner_after = 1;
+            ok($second_nested_after, "second nested after has run");
+        };
+    };
+    describe "second inner" => sub {
+        it "inner block after has run" => sub {
+            ok($inner_after, "inner blocks after has run");
+        };
+        after all => sub {
+            $second_inner_after = 1;
+            ok(1, "after all - second inner");
+        }
+    };
+    xdescribe "TODO context" => sub {
+        it "shouldn't run the after all here" => sub {
+            ok(0);
+        };
+        after all => sub {
+            $todo_after = 1;
+            ok(0, "I should never run\n");
+        };
+    };
+    after all => sub {
+        ok(! $todo_after, "todo after block didn't run");
+        ok($second_inner_after, "second inner after has run");
+    };
+};
+
+runtests;

--- a/t/run_after_spec.t
+++ b/t/run_after_spec.t
@@ -17,7 +17,7 @@ describe "outer describe block" => sub {
                 ok($first_nested_after, "first nested after has run");
             };
             it "doesn't run second nest after until all it's have run" => sub {
-                ok($second_nested_after, "second nested after hasn't run yet")
+                ok(! $second_nested_after, "second nested after hasn't run yet")
             };
             after all => sub {
                 $second_nested_after = 1;


### PR DESCRIPTION
Current implementation means that all the "after all" tear down action happen during global destruction.  This means that the "after all" for a nested describe is not run before the examples in a subsequent nested describe.  This adjusted implementation will "after all" blocks after the last test within their context, but before the examples of any subsequent contexts.  This does come at a performance cost, as after ever test we need to check to see if the next test (if there is one) is in a sibling or parent context.  However by my observation, this performance cost is negligible in the context or running unit tests.

It is not as graceful a solution as allowing global destruction to trigger the "after all" tasks, but it does result in execution of these blocks at what I'd consider to be the expected time during execution.
