### PR TITLE
run tests that match ONE (not all) pattern(s)

### DIFF
--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -142,9 +142,10 @@ sub builder {
 sub _pick_tests {
   my ($class,@matchers) = @_;
   my @tests = $class->tests;
-  for my $pattern (@matchers) {
-    @tests = grep { $_->name =~ /$pattern/i } @tests;
-  }
+
+  my $pattern = join("|", @matchers);
+  @tests = grep { $_->name =~ /$pattern/i } @tests;
+
   return @tests;
 }
 

--- a/t/runtests_subset.t
+++ b/t/runtests_subset.t
@@ -36,6 +36,20 @@ describe "Test::Spec" => sub {
     };
   };
 
+  describe "when more than one specific example is requested explicitly" => sub {
+    my $tap;
+    before all => sub {
+      # case insensitivity is baked in
+      $tap = capture_tap("subset_spec.pl", "oNe", "Two");
+    };
+    it "should run the requested examples" => sub {
+      like $tap, qr/^ok \d+ - Test One.*ok \d+ - Test Two/ms;
+    };
+    it "should run ONLY the requested examples" => sub {
+      unlike $tap, qr/^ok \d+ - Test Three/;
+    };
+  };
+
   describe "when specific examples are requested via SPEC environment var" => sub {
     my $tap;
     before all => sub {

--- a/t/subset_spec.pl
+++ b/t/subset_spec.pl
@@ -14,6 +14,7 @@ BEGIN { require "$Bin/test_helper.pl" };
 describe "Test" => sub {
   it "One" => sub { pass };
   it "Two" => sub { pass };
+  it "Three" => sub { pass };
 };
 
 runtests(@ARGV) unless caller;


### PR DESCRIPTION
Documentation for runtests says:
Runs all the examples whose descriptions match one of the (non case-sensitive) regular expressions in @patterns.

If fact, it runs tests, that match ALL patterns of the array. Fixed the code to match the documentation (including test).