### PR TITLE
Read content file outside of eval block

### DIFF
--- a/lib/Test/Spec.pm
+++ b/lib/Test/Spec.pm
@@ -365,16 +365,19 @@ sub spec_helper ($) {
     my $newdir = File::Spec->catdir($calldir,$filedir);
     $load_path = File::Spec->catpath($callvol,$newdir,$filename);
   }
-  my $sub = eval "package $callpkg;\n" . q[sub {
-    my ($file,$origpath) = @_;
-    open(my $IN, "<", $file)
-      || die "could not open spec_helper '$origpath': $!";
-    defined(my $content = do { local $/; <$IN> })
-      || die "could not read spec_helper '$origpath': $!";
-    eval("# line 1 \"$origpath\"\n" . $content);
-    die "$@\n" if $@;
-  }];
-  $sub->($load_path,$filespec);
+
+  open(my $IN, "<", $load_path)
+    or die "could not open spec_helper '$filespec': $!";
+  defined(my $content = do { local $/; <$IN> })
+    or die "could not read spec_helper '$filespec': $!";
+
+  my $sub = eval "package $callpkg;\n" .
+    q[sub {
+        my ($content) = @_;
+        eval $content;
+        die qq{$@\n} if $@;
+      }];
+  $sub->($content);
 }
 
 sub share(\%) {


### PR DESCRIPTION
spec_helper is sneaking in some content
from a file to a namespace.

But it's not required to read the file
inside the quoted eval.

Reading it earlier provides the advantage
of building the OP tree for it, so
we can use Test::Mockfile without impacting
this test module.

It also reduces the length of the string eval
and optimize it and make it easier to maintain
at the same time.